### PR TITLE
Dockerfile tweaks and WP steps to get PBJ running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ You will need to download and install Docker.
 
 ## Step 2: Clone the Pantheon candela repository
 
-Clone the repository to your laptop to `~/Sites/pbj`.
+Clone the repository to your laptop to `~/Sites/pbj` (likely want to tweak the copied Github clone URL to copy the repo here as opposed to `candela`).
 
 	$ git clone <repo_url> ~/Sites/pbj
 
 ## Step 3: Build and start the PBJ development environment
 
-This will build the Docker images and containers used to serve run project.
+Clone this directory locally. This repo will build the Docker images and containers used to serve run project.
 
 	$ cd ~/pbj-docker
 	$ ./start-everything.sh
@@ -46,11 +46,31 @@ This will build the Docker images and containers used to serve run project.
 The first time this command is used, it will take a while to complete. It will be downloading
 several Debian packages for the various server-side dependencies required by PBJ.
 
+If you need to stop your Docker session you can run `/.stop-everything.sh` or `./delete-everything.sh` to remove images. If something is truly borked running `docker kill $(docker ps -q) && docker rm $(docker ps -a -q) && docker rmi $(docker images -q)` will kill all containers and images. Then you would run `./start-everything.sh` to build from scratch.
+
 ## Step 4: Enjoy!
 
 Your project files are now located in: `~/Sites/pbj`
 Your database files are located in: `~/Sites/pbj-db`
 
-Your Wordpress website is reachable at: [http://localhost:8081/](http://localhost:8081/)
+Your Wordpress website is reachable at: [http://localhost:80/](http://localhost:80/) and it will take you through the Wordpress install (if the port is being tricky which sometimes happened to me at `8080` hitting `http://localhost/wp-admin` also does the trick).
 
 If you need to connect directly to the database, it will be available at localhost:3307.
+
+## Step 5: Configure WP to mirror your Panthen environment
+To mirror the Pantheon environment and get plugins running you have to go through a few steps.
+
+- After WP installation login with new account created
+- Next we want to install Multisite which is required for Pressbooks. Unfortunately this isn't something that can be part of the Docker container as it requires WP as well as local tweaks.
+    - Go to Tools > Network Setup in WP and click Install
+    - Take note of correct settings for your WP install at ~/Sites/pbj
+    - Update your wp-config-local with the correct multisite values provided
+    - Update .htaccess file with correct values provided
+    - After updating if you refresh WP you may be booted out, once you log back in Multisite should be enabled (you can see this if you look in main menu and you have option to add a new site)
+	- Install Pressbooks plugin from Plugin options (in Admin settings, all plugins should already be there that we part of repo)
+	- For look and feel to be correct for PBJ you also want to install `Candela Utility` plugin. Now everything should _look_ the same in PBJ
+	- At this point you should be able to install whatever Plugins you want and all should work hopefully - you may want to do one by one as doing bulk install may error out as some plugins rely on others (such as LTI I believe)
+	- For book themes to be correct you should go to Themes in your admin Dashboard and enable Pressbooks Publisher as the theme, and _then_ enable Bombadil (you may want to enable Luther as well as that is what Bombadil is built off), but pretty sure this isn't necessary). Now for any books created you should be able to use the Bombadil theme and thinks will be looking prettay prettay good.
+	- With plugins and themes enabled now you should be able to add / import books and have things look the same between the local and Pantheon environment you cloned down
+	- Note: If you upgrade plugins things may change or break (this could be good if you are testing)
+

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Clone the repository to your laptop to `~/Sites/pbj` (likely want to tweak the c
 
 ## Step 3: Build and start the PBJ development environment
 
-Clone this directory locally. This repo will build the Docker images and containers used to serve run project.
+Clone this directory locally. This repo will build the Docker images and containers used to build and run project.
 
 	$ cd ~/pbj-docker
 	$ ./start-everything.sh
@@ -51,27 +51,27 @@ If you need to stop your Docker session you can run `/.stop-everything.sh` or `.
 ## Step 4: Enjoy!
 
 Your project files are now located in: `~/Sites/pbj`
-	- Note: Your WP config will be updated in `wp-config-local.php` and that's where you can check out and tweak and WP settings
+	- Note: Your WP config will be updated in `wp-config-local.php` and that's where you can check out and tweak your local WP settings
 Your database files are located in: `~/Sites/pbj-db`
 
 Your Wordpress website is reachable at: [http://localhost:80/](http://localhost:80/) and it will take you through the Wordpress install (if the port is being tricky which sometimes happened to me at `8080` hitting `http://localhost/wp-admin` also does the trick).
 
-If you need to connect directly to the database, it will be available at localhost:3307 (user `pbj` password `pbj`).
+If you need to connect directly to the database, it will be available at localhost:3307 (user `pbj`, password `pbj`).
 
-## Step 5: Configure WP to mirror your Panthen environment
+## Step 5: Configure WP to mirror your Pantheon environment
 To mirror the Pantheon environment and get plugins running you have to go through a few steps.
 
 - After WP installation login with new account created
 - Next we want to install Multisite which is required for Pressbooks. Unfortunately this isn't something that can be part of the Docker container as it requires WP as well as local tweaks.
-    - Go to Tools > Network Setup in WP and click Install
-    - Take note of correct settings for your WP install at ~/Sites/pbj
-    - Update your `wp-config-local.php` with the correct multisite values provided
-    - Update .htaccess file with correct values provided
-    - After updating if you refresh WP you may be booted out, once you log back in Multisite should be enabled (you can see this if you look in main menu and you have option to add a new site)
-	- Install Pressbooks plugin from Plugin options (in Admin settings, all plugins should already be there that we part of repo)
-	- For look and feel to be correct for PBJ you also want to install `Candela Utility` plugin. Now everything should _look_ the same in PBJ
-	- At this point you should be able to install whatever Plugins you want and all should work hopefully - you may want to do one by one as doing bulk install may error out as some plugins rely on others (such as LTI I believe)
-	- For book themes to be correct you should go to Themes in your admin Dashboard and enable Pressbooks Publisher as the theme, and _then_ enable Bombadil (you may want to enable Luther as well as that is what Bombadil is built off), but pretty sure this isn't necessary). Now for any books created you should be able to use the Bombadil theme and thinks will be looking prettay prettay good.
-	- With plugins and themes enabled now you should be able to add / import books and have things look the same between the local and Pantheon environment you cloned down
-	- Note: If you upgrade plugins things may change or break (this could be good if you are testing)
+	- Go to Tools > Network Setup in WP and click Install
+	- Take note of correct settings for your WP install at ~/Sites/pbj
+	- Update your `wp-config-local.php` with the correct multisite values provided
+	- Update .htaccess file with correct values provided
+	- After updating if you refresh WP you may be booted out, once you log back in Multisite should be enabled (you can see this if you look in main menu and you have option to add a new site)
+- Install Pressbooks plugin from Plugin options (in Admin Dashboard > Plugins, and all plugins should already be there that we part of that Pantheon repo)
+- For look and feel to be correct for PBJ you also want to install `Candela Utility` plugin. Now everything should _look_ the same in PBJ
+- At this point you should be able to install whatever Plugins you want and all should work hopefully - you may want to do one by one as doing bulk install may error out as some plugins rely on others (such as LTI I believe)
+- For book themes to be correct you should go to Themes in your admin Dashboard and enable Pressbooks Publisher as the theme, and _then_ enable Bombadil (you may want to enable Luther as well as that is what Bombadil is built off), but pretty sure this isn't necessary). Now for any books created you should be able to use the Bombadil theme and things will be looking prettay prettay good.
+- With plugins and themes enabled now you should be able to add / import books and have things look the same between the local and Pantheon environment you cloned down
+- Note: If you upgrade plugins things may change or break (this could be good if you are testing)
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ If you need to stop your Docker session you can run `/.stop-everything.sh` or `.
 ## Step 4: Enjoy!
 
 Your project files are now located in: `~/Sites/pbj`
+	- Note: Your WP config will be updated in `wp-config-local.php` and that's where you can check out and tweak and WP settings
 Your database files are located in: `~/Sites/pbj-db`
 
 Your Wordpress website is reachable at: [http://localhost:80/](http://localhost:80/) and it will take you through the Wordpress install (if the port is being tricky which sometimes happened to me at `8080` hitting `http://localhost/wp-admin` also does the trick).
 
-If you need to connect directly to the database, it will be available at localhost:3307.
+If you need to connect directly to the database, it will be available at localhost:3307 (user `pbj` password `pbj`).
 
 ## Step 5: Configure WP to mirror your Panthen environment
 To mirror the Pantheon environment and get plugins running you have to go through a few steps.
@@ -64,7 +65,7 @@ To mirror the Pantheon environment and get plugins running you have to go throug
 - Next we want to install Multisite which is required for Pressbooks. Unfortunately this isn't something that can be part of the Docker container as it requires WP as well as local tweaks.
     - Go to Tools > Network Setup in WP and click Install
     - Take note of correct settings for your WP install at ~/Sites/pbj
-    - Update your wp-config-local with the correct multisite values provided
+    - Update your `wp-config-local.php` with the correct multisite values provided
     - Update .htaccess file with correct values provided
     - After updating if you refresh WP you may be booted out, once you log back in Multisite should be enabled (you can see this if you look in main menu and you have option to add a new site)
 	- Install Pressbooks plugin from Plugin options (in Admin settings, all plugins should already be there that we part of repo)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - redis:pbj_redis
     ports:
       - "80:80"
+      - "443:443"
 
     restart: unless-stopped
     privileged: false

--- a/install_wordpress/Dockerfile
+++ b/install_wordpress/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        curl ca-certificates mysql-client php7.0-cli php7.0-mysql && \
+        curl ca-certificates mysql-client php7.2-cli php7.2-mysql && \
 	apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/start-everything.sh
+++ b/start-everything.sh
@@ -10,8 +10,4 @@ if [ "$PROCS" != "0" ]; then
   sudo apachectl stop
 fi
 
-# Start PBJ containers
-mkdir -p ~/pbj
-mkdir -p ~/pbj-db
-
 docker-compose up

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,20 +3,23 @@ FROM ubuntu:18.04
 RUN apt-get update && \
 	apt-get install -y tzdata && \
 	apt-get install -y --no-install-recommends \
-		apache2 libapache2-mod-php7.2 php7.2-mysql php-redis
+		apache2 ssl-cert libapache2-mod-php7.2 php7.2-mysql php-redis
 #		apache2 libapache2-mod-php7.0 php7.0-mysql php7.0-oauth php-redis && \
 #   apt-get clean && \
 #	  rm -rf /var/lib/apt/lists/*
 
-RUN a2enmod rewrite
+RUN a2enmod rewrite && \
+	a2enmod ssl && \
+	a2ensite default-ssl
 
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 RUN sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
 
 
 # Add PHP OAuth extension by temporarily installing packages to download and compile it
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
 	apt-get install -y tzdata && \
+	apt-get install -y --no-install-recommends \
 	php7.2-dev php-pear make && \
 	pecl install oauth-2.0.2 && \
 	apt-get purge -y php7.2-dev php-pear make && \
@@ -27,6 +30,6 @@ RUN apt-get install -y --no-install-recommends \
 COPY start-apache.sh /
 RUN chmod 755 /start-apache.sh
 
-EXPOSE 80
+EXPOSE 80 443
 
 CMD "/start-apache.sh"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -4,15 +4,13 @@ RUN apt-get update && \
 	apt-get install -y tzdata && \
 	apt-get install -y --no-install-recommends \
 		apache2 ssl-cert libapache2-mod-php7.2 php7.2-mysql php-redis
-#		apache2 libapache2-mod-php7.0 php7.0-mysql php7.0-oauth php-redis && \
-#   apt-get clean && \
-#	  rm -rf /var/lib/apt/lists/*
 
+# enable Apache modrewrite and SSL
 RUN a2enmod rewrite && \
 	a2enmod ssl && \
 	a2ensite default-ssl
 
-RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
+# Update apache conf to allow subdirectories
 RUN sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
 
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,18 +1,26 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
+	apt-get install -y tzdata && \
 	apt-get install -y --no-install-recommends \
-		apache2 libapache2-mod-php7.0 php7.0-mysql php-redis
+		apache2 libapache2-mod-php7.2 php7.2-mysql php-redis
 #		apache2 libapache2-mod-php7.0 php7.0-mysql php7.0-oauth php-redis && \
 #   apt-get clean && \
 #	  rm -rf /var/lib/apt/lists/*
 
+RUN a2enmod rewrite
+
+RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
+RUN sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
+
+
 # Add PHP OAuth extension by temporarily installing packages to download and compile it
 RUN apt-get install -y --no-install-recommends \
-	php7.0-dev php-pear make && \
+	apt-get install -y tzdata && \
+	php7.2-dev php-pear make && \
 	pecl install oauth-2.0.2 && \
-	apt-get purge -y php7.0-dev php-pear make && \
-	echo 'extension=oauth.so' >> /etc/php/7.0/apache2/php.ini && \
+	apt-get purge -y php7.2-dev php-pear make && \
+	echo 'extension=oauth.so' >> /etc/php/7.2/apache2/php.ini && \
 	apt-get clean && \
 	rm -rf /var/ilb/apt/lists/*
 


### PR DESCRIPTION
Summary of updates:
- Needed to update Ubuntu to 18.04 so it installed PHP 7.2 by default. Trying to get it working with the older Ubuntu version proved nearly impossible... (required for newer Wordpress install)
- Get SSL working and expose port 443
- Install a few necessary packages for php / SSL / modrewrite
- Enable modrewrite on Apache and update Apache conf to allow writing to sub directories 
- Updated README with all steps to get things in WP working (this was surprisingly difficult at times to figure out the right settings in the right order)

Really all in all this wasn't too much - just took a long time to cobble it altogether to find the right combos!