### PR TITLE
Updating docker file with xdebug install and config

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,7 +3,19 @@ FROM ubuntu:18.04
 RUN apt-get update && \
 	apt-get install -y tzdata && \
 	apt-get install -y --no-install-recommends \
-		apache2 ssl-cert libapache2-mod-php7.2 php7.2-mysql php-redis
+		apache2 ssl-cert php-xdebug libapache2-mod-php7.2 php7.2-mysql php7.2-gd php7.2-mbstring php-redis
+
+# PHP xdebug config 
+# For VS Code related debug setup see https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug
+RUN echo '[xdebug]' >> /etc/php/7.2/apache2/php.ini
+RUN echo 'zend_extension = /usr/lib/php/20170718/xdebug.so' >> /etc/php/7.2/apache2/php.ini
+RUN echo 'xdebug.remote_enable=1' >> /etc/php/7.2/apache2/php.ini
+RUN echo 'xdebug.remote_autostart=1' >> /etc/php/7.2/apache2/php.ini
+RUN echo 'xdebug.remote_port=9001' >> /etc/php/7.2/apache2/php.ini
+RUN echo 'xdebug.remote_connect_back=0' >> /etc/php/7.2/apache2/php.ini
+RUN echo 'xdebug.remote_host=docker.for.mac.localhost' >> /etc/php/7.2/apache2/php.ini
+RUN echo 'xdebug.remote_log=/tmp/xdebug_log/xdebug.log' >> /etc/php/7.2/apache2/php.ini
+
 
 # enable Apache modrewrite and SSL
 RUN a2enmod rewrite && \


### PR DESCRIPTION
Adding `php-xdebug` install to `pbj_web` dockerfile and adding the correct config settings so that debugging can work in preferred IDE on port `9001` (seems port 9000 is reserved in some cases)